### PR TITLE
Modify eslint config for compatibility with GUI

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "parserOptions": {
     "sourceType": "module",
     "ecmaFeatures": {


### PR DESCRIPTION
Adds the root flag to the eslint config so that eslint will not look at eslint configurations in parent directories when using yarn link.

From the eslint [docs](https://eslint.org/docs/user-guide/configuring):

> The first way to use configuration files is via .eslintrc.* and package.json files. ESLint will automatically look for them in the directory of the file to be linted, and in successive parent directories all the way up to the root directory of the filesystem (unless root: true is specified).