### PR TITLE
Relax omega chart

### DIFF
--- a/src/jsx/components/omega_plots.jsx
+++ b/src/jsx/components/omega_plots.jsx
@@ -5,6 +5,28 @@ var _ = require("underscore");
 var d3_save_svg = require("d3-save-svg");
 
 var OmegaPlot = React.createClass({
+  componentDidMount: function() {
+    this.initialize();
+  },
+
+  componentWillReceiveProps: function(nextProps) {
+    this.setState({
+      omegas: nextProps.omegas
+    });
+  },
+
+  componentDidUpdate: function() {
+    d3.select("#" + this.svg_id).html("");
+    this.initialize();
+  },
+
+  getInitialState: function() {
+    return {
+      omegas: this.props.omegas,
+      settings: this.props.settings
+    };
+  },
+
   getDefaultProps: function() {
     return {
       svg_id: null,
@@ -143,6 +165,7 @@ var OmegaPlot = React.createClass({
     this.createXAxis();
     this.createYAxis();
   },
+
   makeSpring: function(x1, x2, y1, y2, step, displacement) {
     if (x1 == x2) {
       y1 = Math.min(y1, y2);
@@ -186,6 +209,7 @@ var OmegaPlot = React.createClass({
     var line = d3.svg.line().interpolate("monotone");
     return line(spring_data);
   },
+
   createDisplacementLine: function() {
     var self = this;
     var data_to_plot = this.state.omegas["Reference"];
@@ -220,6 +244,7 @@ var OmegaPlot = React.createClass({
         .attr("class", "hyphy-displacement-line");
     }
   },
+
   createReferenceLine: function() {
     var data_to_plot = this.state.omegas["Reference"];
     var secondary_data = this.state.omegas["Test"];
@@ -255,6 +280,7 @@ var OmegaPlot = React.createClass({
       this.displacement_lines.remove();
     }
   },
+
   createOmegaLine: function() {
     var data_to_plot = this.state.omegas["Reference"];
     var secondary_data = this.state.omegas["Test"];
@@ -285,6 +311,7 @@ var OmegaPlot = React.createClass({
       })
       .attr("class", "hyphy-omega-line");
   },
+
   createNeutralLine: function() {
     var self = this;
 
@@ -306,6 +333,7 @@ var OmegaPlot = React.createClass({
       .attr("y1", 0)
       .attr("y2", this.plot_height);
   },
+
   createXAxis: function() {
     // *** X-AXIS *** //
     var xAxis = d3.svg
@@ -314,7 +342,7 @@ var OmegaPlot = React.createClass({
       .orient("bottom");
 
     if (this.do_log_plot) {
-      xAxis.ticks(10, this.has_zeros ? ".2r" : ".1r");
+      xAxis.ticks(10, ".0e");
     }
 
     var x_axis = this.svg.selectAll(".x.axis");
@@ -337,7 +365,10 @@ var OmegaPlot = React.createClass({
           (this.plot_height + this.margins["top"]) +
           ")"
       )
-      .call(xAxis);
+      .call(xAxis)
+      .selectAll("text")
+      .style("text-anchor", "end")
+      .attr("transform", "rotate(-45)");
     x_label = x_label
       .attr(
         "transform",
@@ -353,6 +384,7 @@ var OmegaPlot = React.createClass({
       .style("text-anchor", "end")
       .attr("dy", "0.0em");
   },
+
   createYAxis: function() {
     // *** Y-AXIS *** //
     var yAxis = d3.svg
@@ -387,29 +419,6 @@ var OmegaPlot = React.createClass({
       })
       .style("text-anchor", "start")
       .attr("dy", "-1em");
-  },
-
-  getInitialState: function() {
-    return {
-      omegas: this.props.omegas,
-      settings: this.props.settings
-    };
-  },
-
-  componentWillReceiveProps: function(nextProps) {
-    this.setState({
-      omegas: nextProps.omegas
-    });
-  },
-
-  componentDidUpdate: function() {
-    d3.select("#" + this.svg_id).html("");
-
-    this.initialize();
-  },
-
-  componentDidMount: function() {
-    this.initialize();
   },
 
   render: function() {

--- a/src/jsx/components/omega_plots.jsx
+++ b/src/jsx/components/omega_plots.jsx
@@ -164,6 +164,7 @@ var OmegaPlot = React.createClass({
     this.createReferenceLine();
     this.createXAxis();
     this.createYAxis();
+    this.createLegend();
   },
 
   makeSpring: function(x1, x2, y1, y2, step, displacement) {
@@ -369,6 +370,7 @@ var OmegaPlot = React.createClass({
       .selectAll("text")
       .style("text-anchor", "end")
       .attr("transform", "rotate(-45)");
+
     x_label = x_label
       .attr(
         "transform",
@@ -421,6 +423,49 @@ var OmegaPlot = React.createClass({
       .attr("dy", "-1em");
   },
 
+  createLegend: function() {
+    let legendData = [20, 1000];
+    let legendColors = ["#00a99d", "black"];
+    let labels = ["Test", "Reference"];
+    let legendSquareSize = 20;
+    let legendSpacing = 5;
+    let legendX = this.props.settings.dimensions.width - 100;
+    let fontSizeOffset = 15;
+
+    var legend = this.svg
+      .selectAll(".legend")
+      .data(legendData)
+      .enter()
+      .append("g");
+
+    legend
+      .append("rect")
+      .attr("fill", function(d, i) {
+        return legendColors[i];
+      })
+      .attr("width", legendSquareSize)
+      .attr("height", legendSquareSize)
+      .attr("y", function(d, i) {
+        return legendSquareSize + i * (legendSquareSize + legendSpacing);
+      })
+      .attr("x", legendX);
+
+    legend
+      .append("text")
+      .attr("class", "label")
+      .attr("y", function(d, i) {
+        return (
+          legendSquareSize +
+          (i * (legendSquareSize + legendSpacing) + fontSizeOffset)
+        );
+      })
+      .attr("x", legendX + legendSquareSize + 5)
+      .attr("text-anchor", "start")
+      .text(function(d, i) {
+        return labels[i];
+      });
+  },
+
   render: function() {
     var self = this,
       key = this.props.omegas.key,
@@ -434,18 +479,6 @@ var OmegaPlot = React.createClass({
             <h3 className="card-title">
               &omega; distributions under the <strong>{label}</strong> model
             </h3>
-            <p>
-              <small>
-                Test branches are shown in{" "}
-                <span style={{ color: "#00a99d", fontWeight: "bold" }}>
-                  green
-                </span>{" "}
-                and reference branches are shown in{" "}
-                <span style={{ color: "black", fontWeight: "bold" }}>
-                  black
-                </span>
-              </small>
-            </p>
             <div className="btn-group">
               <button
                 onClick={() => {

--- a/src/jsx/components/omega_plots.jsx
+++ b/src/jsx/components/omega_plots.jsx
@@ -36,7 +36,8 @@ var OmegaPlot = React.createClass({
       legend_id: null,
       do_log_plot: true,
       k_p: null,
-      plot: null
+      plot: null,
+      legendBuffer: 100
     };
   },
 
@@ -118,7 +119,7 @@ var OmegaPlot = React.createClass({
     // maximum diameter is (height - text margin)
     this.svg = d3
       .select("#" + this.svg_id)
-      .attr("width", dimensions.width)
+      .attr("width", dimensions.width + this.props.settings.legendBuffer)
       .attr("height", dimensions.height);
     this.svg
       .append("rect")
@@ -429,7 +430,7 @@ var OmegaPlot = React.createClass({
     let labels = ["Test", "Reference"];
     let legendSquareSize = 20;
     let legendSpacing = 5;
-    let legendX = this.props.settings.dimensions.width - 100;
+    let legendX = this.props.settings.dimensions.width;
     let fontSizeOffset = 15;
 
     var legend = this.svg
@@ -574,7 +575,8 @@ var OmegaPlotGrid = React.createClass({
         legend_id: null,
         do_log_plot: true,
         k_p: null,
-        plot: null
+        plot: null,
+        legendBuffer: 100
       };
 
       return (


### PR DESCRIPTION
Adresses #91 and #92.

__before__ (no exportable legend and labels overlapping):
<img width="930" alt="screen shot 2018-07-31 at 1 57 41 pm" src="https://user-images.githubusercontent.com/25244432/43477698-dabb38ac-94c9-11e8-9026-7bdb3897cfea.png">

__after__:
<img width="937" alt="screen shot 2018-07-31 at 2 53 36 pm" src="https://user-images.githubusercontent.com/25244432/43480536-978eb27c-94d1-11e8-8735-385fb0a0f00b.png">

_updated to account for the third commit sliding the legend out of the way of potential conflicts_
