### PR TITLE
Absrel tree tooltip located next to mouse

### DIFF
--- a/src/application.scss
+++ b/src/application.scss
@@ -1524,7 +1524,8 @@ input[type="range"]:focus::-ms-fill-upper {
 
 #tree_tooltip {
   color: #fff;
-  position: absolute;
+  display: block;
+  position: fixed;
   padding: 20px;
   max-width: 200px;
 

--- a/src/jsx/absrel.jsx
+++ b/src/jsx/absrel.jsx
@@ -254,6 +254,15 @@ class BSRELContents extends React.Component {
             .html("");
         });
 
+        var treeTooltipElement = document.getElementById("tree_tooltip");
+
+        window.onmousemove = function(e) {
+          var x = e.clientX;
+          var y = e.clientY;
+          treeTooltipElement.style.top = y + 20 + "px";
+          treeTooltipElement.style.left = x + 20 + "px";
+        };
+
         createBranchGradient(data.target);
 
         if (data.target.grad) {


### PR DESCRIPTION
Closes #133 

__Before:__
![tooltipbefore](https://user-images.githubusercontent.com/25244432/43544109-f5ebd542-959f-11e8-983a-2d643ab5d8ad.gif)

__After:__
![tooltipafter](https://user-images.githubusercontent.com/25244432/43544130-fd70124c-959f-11e8-8777-e160f70e5007.gif)

