### PR TITLE
Remove vision.hyphy.org specific scss from library build

### DIFF
--- a/src/application.scss
+++ b/src/application.scss
@@ -284,8 +284,6 @@ toolbar-dropdown::before {
 }
 
 /* Sizing classes must be here rather than on individual form elements. */
-.input-group {
-}
 
 /* TABLES */
 table {
@@ -1401,106 +1399,6 @@ li.active > a:hover {
   shape-rendering: crispEdges;
 }
 
-input[type="range"] {
-  /*removes default webkit styles*/
-  -webkit-appearance: none;
-
-  /*fix for FF unable to apply focus style bug */
-  border: 1px solid white;
-
-  /*required for proper track sizing in FF*/
-  width: 300px;
-}
-
-input[type="range"]::-webkit-slider-runnable-track {
-  width: 300px;
-  height: 5px;
-  background: #ddd;
-  border: none;
-  border-radius: 3px;
-}
-
-input[type="range"]::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  border: none;
-  height: 16px;
-  width: 16px;
-  border-radius: 50%;
-  background: #00a99d;
-  margin-top: -4px;
-}
-
-input[type="range"]:focus {
-  outline: none;
-}
-
-input[type="range"]:focus::-webkit-slider-runnable-track {
-  background: #ccc;
-}
-
-input[type="range"]::-moz-range-track {
-  width: 300px;
-  height: 5px;
-  background: #ddd;
-  border: none;
-  border-radius: 3px;
-}
-
-input[type="range"]::-moz-range-thumb {
-  border: none;
-  height: 16px;
-  width: 16px;
-  border-radius: 50%;
-  background: #00a99d;
-}
-
-/*hide the outline behind the border*/
-input[type="range"]:-moz-focusring {
-  outline: 1px solid white;
-  outline-offset: -1px;
-}
-
-input[type="range"]::-ms-track {
-  width: 300px;
-  height: 5px;
-
-  /*remove bg colour from the track, we'll use ms-fill-lower and ms-fill-upper instead */
-  background: transparent;
-
-  /*leave room for the larger thumb to overflow with a transparent border */
-  border-color: transparent;
-  border-width: 6px 0;
-
-  /*remove default tick marks*/
-  color: transparent;
-}
-
-input[type="range"]::-ms-fill-lower {
-  background: #777;
-  border-radius: 10px;
-}
-
-input[type="range"]::-ms-fill-upper {
-  background: #ddd;
-  border-radius: 10px;
-}
-
-input[type="range"]::-ms-thumb {
-  border: none;
-  height: 16px;
-  width: 16px;
-  border-radius: 50%;
-  background: #00a99d;
-}
-
-input[type="range"]:focus::-ms-fill-lower {
-  background: #888;
-}
-
-input[type="range"]:focus::-ms-fill-upper {
-  background: #ccc;
-}
-
 .modal .modal-dialog {
   width: 850px;
   max-width: 850px;
@@ -1679,10 +1577,6 @@ input[type="range"]:focus::-ms-fill-upper {
   } 
 }
 */
-
-input[type="file"] {
-  display: none;
-}
 
 .custom-file-upload {
   border: 1px solid #ccc;

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 require("font-awesome/css/font-awesome.css");
-require("./hyphyvision.css");
 require("./fade/FADE.css");
 require("bootstrap");
 require("./datamonkey/datamonkey.js");
 require("./application.scss");
+require("./website.scss");
 
 import render_app from "./jsx/app.jsx";
 

--- a/src/jsx/relax.jsx
+++ b/src/jsx/relax.jsx
@@ -1,12 +1,12 @@
+import React from "react";
+import ReactDOM from "react-dom";
 import { Tree } from "./components/tree.jsx";
 import { OmegaPlotGrid } from "./components/omega_plots.jsx";
 import { Header } from "./components/header.jsx";
 import { DatamonkeyTable } from "./components/tables.jsx";
 import { MainResult } from "./components/mainresult.jsx";
 import { ResultsPage } from "./components/results_page.jsx";
-
-var React = require("react"),
-  _ = require("underscore");
+var _ = require("underscore");
 
 class RELAXModelTable extends React.Component {
   constructor(props) {

--- a/src/website.scss
+++ b/src/website.scss
@@ -1,0 +1,103 @@
+input[type="range"] {
+  /*removes default webkit styles*/
+  -webkit-appearance: none;
+
+  /*fix for FF unable to apply focus style bug */
+  border: 1px solid white;
+
+  /*required for proper track sizing in FF*/
+  width: 300px;
+}
+
+input[type="range"]::-webkit-slider-runnable-track {
+  width: 300px;
+  height: 5px;
+  background: #ddd;
+  border: none;
+  border-radius: 3px;
+}
+
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  border: none;
+  height: 16px;
+  width: 16px;
+  border-radius: 50%;
+  background: #00a99d;
+  margin-top: -4px;
+}
+
+input[type="range"]:focus {
+  outline: none;
+}
+
+input[type="range"]:focus::-webkit-slider-runnable-track {
+  background: #ccc;
+}
+
+input[type="range"]::-moz-range-track {
+  width: 300px;
+  height: 5px;
+  background: #ddd;
+  border: none;
+  border-radius: 3px;
+}
+
+input[type="range"]::-moz-range-thumb {
+  border: none;
+  height: 16px;
+  width: 16px;
+  border-radius: 50%;
+  background: #00a99d;
+}
+
+/*hide the outline behind the border*/
+input[type="range"]:-moz-focusring {
+  outline: 1px solid white;
+  outline-offset: -1px;
+}
+
+input[type="range"]::-ms-track {
+  width: 300px;
+  height: 5px;
+
+  /*remove bg colour from the track, we'll use ms-fill-lower and ms-fill-upper instead */
+  background: transparent;
+
+  /*leave room for the larger thumb to overflow with a transparent border */
+  border-color: transparent;
+  border-width: 6px 0;
+
+  /*remove default tick marks*/
+  color: transparent;
+}
+
+input[type="range"]::-ms-fill-lower {
+  background: #777;
+  border-radius: 10px;
+}
+
+input[type="range"]::-ms-fill-upper {
+  background: #ddd;
+  border-radius: 10px;
+}
+
+input[type="range"]::-ms-thumb {
+  border: none;
+  height: 16px;
+  width: 16px;
+  border-radius: 50%;
+  background: #00a99d;
+}
+
+input[type="range"]:focus::-ms-fill-lower {
+  background: #888;
+}
+
+input[type="range"]:focus::-ms-fill-upper {
+  background: #ccc;
+}
+
+input[type="file"] {
+  display: none;
+}


### PR DESCRIPTION
The special styling for the input (load) button used on the vision site:
<img width="308" alt="screen shot 2018-08-21 at 12 11 47 pm" src="https://user-images.githubusercontent.com/25244432/44414288-6a4ec200-a53b-11e8-90ed-e737046f9c0a.png">

Caused issues with datamonkey-js, where the file load button wasn't visable:
![screen shot 2018-08-21 at 12 13 18 pm](https://user-images.githubusercontent.com/25244432/44414378-9d915100-a53b-11e8-97ec-7ccd16212c96.png)

This PR separates out the styling that is only used for the site and not the library (i.e. styling for the navbar) and doesn't package that scss in the library build. Thus fixing the datamonkey issue (screenshot from yalc linking this commit of hyphy-vision into datamonkey-js):
![screen shot 2018-08-21 at 12 16 44 pm](https://user-images.githubusercontent.com/25244432/44414573-1abcc600-a53c-11e8-9d55-513a903f52d2.png)

I also webpacked and built vision.hyphy.org to ensure that still worked properly with these changes.