### PR TITLE
Fix scrollspy bug

### DIFF
--- a/src/jsx/components/results_page.jsx
+++ b/src/jsx/components/results_page.jsx
@@ -38,15 +38,13 @@ class ResultsPage extends React.Component {
   componentDidUpdate(prevProps, prevState) {
     var self = this;
     // Decide if data is a URL or the results JSON
-    var newData;
+    var newData = this.state.json;
     if (typeof this.props.data == "string") {
       if (this.props.data != self.state.jsonPath) {
         d3.json(this.props.data, function(data) {
           //self.setState({ json: data });
           newData = data;
         });
-      } else {
-        newData = this.state.json;
       }
     } else if (typeof this.props.data == "object") {
       //self.setState({ json: self.props.data })

--- a/src/jsx/components/results_page.jsx
+++ b/src/jsx/components/results_page.jsx
@@ -16,7 +16,8 @@ class ResultsPage extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      json: null
+      json: null,
+      jsonPath: null
     };
   }
 
@@ -24,6 +25,7 @@ class ResultsPage extends React.Component {
     var self = this;
     // Decide if data is a URL or the results JSON
     if (typeof this.props.data == "string") {
+      self.setState({ jsonPath: this.props.data }); // Set the json path for comparing on updates to see if it's new data.
       d3.json(this.props.data, function(data) {
         self.setState({ json: data });
       });
@@ -38,10 +40,14 @@ class ResultsPage extends React.Component {
     // Decide if data is a URL or the results JSON
     var newData;
     if (typeof this.props.data == "string") {
-      d3.json(this.props.data, function(data) {
-        //self.setState({ json: data });
-        newData = data;
-      });
+      if (this.props.data != self.state.jsonPath) {
+        d3.json(this.props.data, function(data) {
+          //self.setState({ json: data });
+          newData = data;
+        });
+      } else {
+        newData = this.state.json;
+      }
     } else if (typeof this.props.data == "object") {
       //self.setState({ json: self.props.data })
       newData = self.props.data;


### PR DESCRIPTION
This fixes a bug introduced by this commit https://github.com/veg/hyphy-vision/commit/824bbd43a3542fb1f03c4427524537d89ead7a82 that caused a blank screen when the anchor tags were clicked.

The issue was that on the ResultsPage's componentDidUpdate function being called (which happens when the anchor tags are clicked) the data was loaded with `d3.json` and then compared to the existing data (if the data wasn't different, the component wouldn't update; however, because `d3.json` is asynchronous, we would be comparing the previous data to undefined while the data was loading and then try to set `state.json` to `undefined`. I addressed this by comparing the url/path (if the data prop is a string) rather than calling `d3.json` and comparing the actual data. The bug is fixed.