### PR TITLE
Disable radial trees

### DIFF
--- a/src/jsx/components/tree.jsx
+++ b/src/jsx/components/tree.jsx
@@ -751,7 +751,10 @@ var Tree = React.createClass({
         </h4>
 
         <div className="row">
-          <div className="col-12">
+          <div
+            className="col-12"
+            style={{ display: "flex", justifyContent: "space-between" }}
+          >
             <div className="input-group-btn">
               <button
                 type="button"
@@ -764,7 +767,9 @@ var Tree = React.createClass({
               <ul className="dropdown-menu" id="hyphy-tree-model-list">
                 {this.getMainList()}
               </ul>
+            </div>
 
+            <div className="input-group-btn">
               <button
                 type="button"
                 className="btn btn-secondary btn-sm"
@@ -783,6 +788,8 @@ var Tree = React.createClass({
               >
                 <i className="fa  fa-compress fa-rotate-135" />
               </button>
+            </div>
+            <div className="input-group-btn">
               <button
                 type="button"
                 className="btn btn-secondary btn-sm"
@@ -854,48 +861,6 @@ var Tree = React.createClass({
               </button>
             </div>
 
-            <div className="input-group-btn float-right">
-              <button
-                type="button"
-                className="btn btn-secondary dropdown-toggle"
-                data-toggle="dropdown"
-              >
-                Export <span className="caret" />
-              </button>
-              <ul className="dropdown-menu">
-                <li id="export-phylo-png">
-                  <a
-                    onClick={() =>
-                      saveSvgAsPng(
-                        document.getElementById("dm-phylotree"),
-                        "tree.png"
-                      )
-                    }
-                    href="javascript:;"
-                  >
-                    <i className="fa fa-image" /> PNG
-                  </a>
-                </li>
-                <li id="export-phylo-png">
-                  <a
-                    onClick={() =>
-                      d3_save_svg.save(d3.select("#dm-phylotree").node(), {
-                        filename: "tree"
-                      })
-                    }
-                    href="javascript:;"
-                  >
-                    <i className="fa fa-image" /> SVG
-                  </a>
-                </li>
-                <li id="export-phylo-nwk">
-                  <a onClick={this.exportNewick} href="javascript:;">
-                    <i className="fa fa-file-o" /> Newick File
-                  </a>
-                </li>
-              </ul>
-            </div>
-
             <div className="input-group-btn">
               <button
                 type="button"
@@ -907,6 +872,48 @@ var Tree = React.createClass({
               </button>
 
               {this.settingsMenu()}
+
+              <div className="input-group-btn float-right">
+                <button
+                  type="button"
+                  className="btn btn-secondary dropdown-toggle"
+                  data-toggle="dropdown"
+                >
+                  Export <span className="caret" />
+                </button>
+                <ul className="dropdown-menu">
+                  <li id="export-phylo-png">
+                    <a
+                      onClick={() =>
+                        saveSvgAsPng(
+                          document.getElementById("dm-phylotree"),
+                          "tree.png"
+                        )
+                      }
+                      href="javascript:;"
+                    >
+                      <i className="fa fa-image" /> PNG
+                    </a>
+                  </li>
+                  <li id="export-phylo-png">
+                    <a
+                      onClick={() =>
+                        d3_save_svg.save(d3.select("#dm-phylotree").node(), {
+                          filename: "tree"
+                        })
+                      }
+                      href="javascript:;"
+                    >
+                      <i className="fa fa-image" /> SVG
+                    </a>
+                  </li>
+                  <li id="export-phylo-nwk">
+                    <a onClick={this.exportNewick} href="javascript:;">
+                      <i className="fa fa-file-o" /> Newick File
+                    </a>
+                  </li>
+                </ul>
+              </div>
             </div>
           </div>
         </div>

--- a/src/jsx/components/tree.jsx
+++ b/src/jsx/components/tree.jsx
@@ -801,30 +801,32 @@ var Tree = React.createClass({
               </button>
             </div>
 
-            <div className="btn-group-toggle" data-toggle="buttons">
-              <button className="btn btn-secondary active">
-                <input
-                  type="radio"
-                  name="options"
-                  className="phylotree-layout-mode"
-                  data-mode="linear"
-                  autoComplete="off"
-                  checked=""
-                  title="Layout left-to-right"
-                />Linear
-              </button>
-              <button className="btn btn-secondary">
-                <input
-                  type="radio"
-                  name="options"
-                  className="phylotree-layout-mode"
-                  data-mode="radial"
-                  autoComplete="off"
-                  title="Layout radially"
-                />{" "}
-                Radial
-              </button>
-            </div>
+            {this.props.settings.allowRadial ? (
+              <div className="btn-group-toggle" data-toggle="buttons">
+                <button className="btn btn-secondary active">
+                  <input
+                    type="radio"
+                    name="options"
+                    className="phylotree-layout-mode"
+                    data-mode="linear"
+                    autoComplete="off"
+                    checked=""
+                    title="Layout left-to-right"
+                  />Linear
+                </button>
+                <button className="btn btn-secondary">
+                  <input
+                    type="radio"
+                    name="options"
+                    className="phylotree-layout-mode"
+                    data-mode="radial"
+                    autoComplete="off"
+                    title="Layout radially"
+                  />{" "}
+                  Radial
+                </button>
+              </div>
+            ) : null}
 
             <div className="btn-group-toggle" data-toggle="buttons">
               <button className="btn btn-secondary active">
@@ -852,7 +854,7 @@ var Tree = React.createClass({
               </button>
             </div>
 
-            <div className="input-group-btn">
+            <div className="input-group-btn float-right">
               <button
                 type="button"
                 className="btn btn-secondary dropdown-toggle"


### PR DESCRIPTION
Temporarily disable the radial tree option until we get a working version of the radial trees in vision. The toolbar now looks like this: 
<img width="980" alt="screen shot 2018-09-13 at 3 41 09 pm" src="https://user-images.githubusercontent.com/25244432/45511667-9d1b5d00-b76b-11e8-8d78-ac0cace731c5.png">
