### PR TITLE
Fix issue with csv exports on datamonkey.org

### DIFF
--- a/src/jsx/components/tables.jsx
+++ b/src/jsx/components/tables.jsx
@@ -4,6 +4,7 @@ var React = require("react"),
   datamonkey = require("../../datamonkey/datamonkey.js");
 
 require("csvexport");
+import CsvExport from "csvexport";
 
 import PropTypes from "prop-types";
 
@@ -433,8 +434,12 @@ var DatamonkeyTable = React.createClass({
           var headers = _.map(self.props.headerData, extract),
             munged = _.map(self.props.bodyData, row => _.map(row, extract)).map(
               row => _.object(headers, row)
-            ),
-            exporter = Export.create();
+            );
+          try {
+            var exporter = Export.create();
+          } catch (err) {
+            var exporter = CsvExport.create();
+          }
           exporter.downloadCsv(munged);
         };
         button = (


### PR DESCRIPTION
The "export to csv" button on the SLAC table stoped working in datamonkey.org as pointed out by this issue: https://github.com/veg/hyphy/issues/844

This PR addresses the issue and uses the try/catch statement to allow the export button to work on both vision.hyphy.org and datamonkey.org.