### PR TITLE
One render_function to rule them all

### DIFF
--- a/__tests__/determineHyPhyMethod.test.js
+++ b/__tests__/determineHyPhyMethod.test.js
@@ -1,0 +1,36 @@
+import { default as determineHyPhyMethod } from "../src/helpers/determineHyPhyMethod.js";
+const exampleAbsrel = require("./../data/json_files/absrel/CD2.fna.ABSREL.json");
+const exampleBgm = require("./../data/json_files/bgm/BGM.json");
+const exampleBusted = require("./../data/json_files/busted/CD2.fna.BUSTED.json");
+const exampleFade = require("./../data/json_files/fade/CD2_AA.fasta.FADE.json");
+const exampleFel = require("./../data/json_files/fel/CD2.fna.FEL.json");
+const exampleFubar = require("./../data/json_files/fubar/CD2.fna.FUBAR.json");
+const exampleGard = require("./../data/json_files/gard/CD2.fasta.GARD.json");
+const exampleMeme = require("./../data/json_files/meme/CD2.fna.MEME.json");
+const exampleRelax = require("./../data/json_files/relax/CD2.fna.RELAX.json");
+const exampleSlac = require("./../data/json_files/slac/CD2.fna.SLAC.json");
+
+describe("determineHyPhyMethod", () => {
+  it("should work on the example json files", () => {
+    expect(determineHyPhyMethod(exampleAbsrel)).toBe("absrel");
+    expect(determineHyPhyMethod(exampleBgm)).toBe("bgm");
+    expect(determineHyPhyMethod(exampleBusted)).toBe("busted");
+    expect(determineHyPhyMethod(exampleFade)).toBe("fade");
+    expect(determineHyPhyMethod(exampleFel)).toBe("fel");
+    expect(determineHyPhyMethod(exampleFubar)).toBe("fubar");
+    expect(determineHyPhyMethod(exampleGard)).toBe("gard");
+    expect(determineHyPhyMethod(exampleRelax)).toBe("relax");
+    expect(determineHyPhyMethod(exampleSlac)).toBe("slac");
+  });
+
+  it("should return a message if the json is empty", () => {
+    expect(determineHyPhyMethod("")).toBe("No json object was proviced");
+    expect(determineHyPhyMethod()).toBe("No json object was proviced");
+    expect(determineHyPhyMethod(undefined)).toBe("No json object was proviced");
+    expect(determineHyPhyMethod(null)).toBe("No json object was proviced");
+  });
+
+  it("should return 'unkownMethod' if the json isn't in the right format", () => {
+    expect(determineHyPhyMethod({ badJson: 1 })).toBe("unknownMethod");
+  });
+});

--- a/__tests__/determineHyPhyMethod.test.js
+++ b/__tests__/determineHyPhyMethod.test.js
@@ -24,10 +24,10 @@ describe("determineHyPhyMethod", () => {
   });
 
   it("should return a message if the json is empty", () => {
-    expect(determineHyPhyMethod("")).toBe("No json object was proviced");
-    expect(determineHyPhyMethod()).toBe("No json object was proviced");
-    expect(determineHyPhyMethod(undefined)).toBe("No json object was proviced");
-    expect(determineHyPhyMethod(null)).toBe("No json object was proviced");
+    expect(determineHyPhyMethod("")).toBe("No json object was provided");
+    expect(determineHyPhyMethod()).toBe("No json object was provided");
+    expect(determineHyPhyMethod(undefined)).toBe("No json object was provided");
+    expect(determineHyPhyMethod(null)).toBe("No json object was provided");
   });
 
   it("should return 'unkownMethod' if the json isn't in the right format", () => {

--- a/src/helpers/determineHyPhyMethod.js
+++ b/src/helpers/determineHyPhyMethod.js
@@ -1,0 +1,43 @@
+function determineHyPhyMethod(json) {
+  // Take a HyPhy JSON result and return a lowercase string of which HyPhy method produced the result.
+
+  if (json == "" || json == undefined || json == null) {
+    return "No json object was proviced";
+  }
+
+  var method;
+
+  if (json["analysis"] != undefined) {
+    const analysisString = json["analysis"]["info"];
+
+    if (analysisString.includes("aBSREL")) {
+      method = "absrel";
+    } else if (analysisString.includes("BGM")) {
+      method = "bgm";
+    } else if (analysisString.includes("BUSTED")) {
+      method = "busted";
+    } else if (analysisString.includes("FADE")) {
+      method = "fade";
+    } else if (analysisString.includes("FEL")) {
+      method = "fel";
+    } else if (analysisString.includes("FADE")) {
+      method = "fade";
+    } else if (analysisString.includes("FUBAR")) {
+      method = "fubar";
+    } else if (analysisString.includes("RELAX")) {
+      method = "relax";
+    } else if (analysisString.includes("SLAC")) {
+      method = "slac";
+    } else {
+      method = "unknownMethod";
+    }
+  } else if (json["breakpointData"] != undefined) {
+    method = "gard";
+  } else {
+    method = "unknownMethod";
+  }
+
+  return method;
+}
+
+module.exports = determineHyPhyMethod;

--- a/src/helpers/determineHyPhyMethod.js
+++ b/src/helpers/determineHyPhyMethod.js
@@ -2,7 +2,7 @@ function determineHyPhyMethod(json) {
   // Take a HyPhy JSON result and return a lowercase string of which HyPhy method produced the result.
 
   if (json == "" || json == undefined || json == null) {
-    return "No json object was proviced";
+    return "No json object was provided";
   }
 
   var method;

--- a/src/jsx/components/inputErrorPage.jsx
+++ b/src/jsx/components/inputErrorPage.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+const ReactDOM = require("react-dom");
+
+function InputErrorPage(props) {
+  return (
+    <div className="row">
+      <div className="clearance" id="summary-div" />
+      <div className="col-md-12">
+        <h3 className="list-group-item-heading">
+          <span id="summary-method-name">
+            ERROR: This JSON format is not compatible with HyPhy Vision
+          </span>
+        </h3>
+      </div>
+    </div>
+  );
+}
+
+function render_inputErrorPage(element) {
+  ReactDOM.render(<InputErrorPage />, document.getElementById(element));
+}
+
+module.exports = render_inputErrorPage;

--- a/src/library-entry.js
+++ b/src/library-entry.js
@@ -15,6 +15,9 @@ export { default as gard } from "./jsx/gard.jsx";
 export { default as bgm } from "./jsx/bgm.jsx";
 export { default as fade } from "./jsx/fade.jsx";
 
+// renderHyPhyVision is for use in Galaxy
+export { defualt as renderHyPhyVision } from "./renderHyPhyVision.js";
+
 // Shared_component exports.
 export {
   default as render_branch_selection

--- a/src/library-entry.js
+++ b/src/library-entry.js
@@ -16,7 +16,7 @@ export { default as bgm } from "./jsx/bgm.jsx";
 export { default as fade } from "./jsx/fade.jsx";
 
 // renderHyPhyVision is for use in Galaxy
-export { defualt as renderHyPhyVision } from "./renderHyPhyVision.js";
+export { default as renderHyPhyVision } from "./renderHyPhyVision.js";
 
 // Shared_component exports.
 export {

--- a/src/renderHyPhyVision.js
+++ b/src/renderHyPhyVision.js
@@ -1,0 +1,42 @@
+import { default as absrel } from "./jsx/absrel.jsx";
+import { default as busted } from "./jsx/busted.jsx";
+import { default as fel } from "./jsx/fel.jsx";
+import { default as meme } from "./jsx/meme.jsx";
+import { default as prime } from "./jsx/prime.jsx";
+import { default as relax } from "./jsx/relax.jsx";
+import { default as slac } from "./jsx/slac.jsx";
+import { default as fubar } from "./jsx/fubar.jsx";
+import { default as gard } from "./jsx/gard.jsx";
+import { default as bgm } from "./jsx/bgm.jsx";
+import { default as fade } from "./jsx/fade.jsx";
+import { default as determineHyPhyMethod } from "./helpers/determineHyPhyMethod.js";
+import { default as render_inputErrorPage } from "./jsx/components/inputErrorPage.jsx";
+
+const methodDict = {
+  absrel: absrel,
+  busted: busted,
+  fel: fel,
+  meme: meme,
+  prime: prime,
+  relax: relax,
+  slac: slac,
+  fubar: fubar,
+  gard: gard,
+  bgm: bgm,
+  fade: fade
+};
+
+function renderHyPhyVision(data, element, fasta, originalFile, analysisLog) {
+  const method = determineHyPhyMethod(data);
+  if (method != "unkownMethod" && method != "No json object was proviced") {
+    const renderSpecificMethod = methodDict[method];
+    console.log("renderSpecificMethod: ", renderSpecificMethod);
+    renderSpecificMethod(data, element, fasta, originalFile, analysisLog);
+    return null;
+  } else {
+    render_inputErrorPage(element);
+    return null;
+  }
+}
+
+module.exports = renderHyPhyVision;

--- a/src/renderHyPhyVision.js
+++ b/src/renderHyPhyVision.js
@@ -26,16 +26,18 @@ const methodDict = {
   fade: render_fade
 };
 
-function renderHyPhyVision(data, element, fasta, originalFile, analysisLog) {
-  const method = determineHyPhyMethod(data);
-  if (method != "unkownMethod" && method != "No json object was provided") {
-    const renderSpecificMethod = methodDict[method];
-    renderSpecificMethod(data, element, fasta, originalFile, analysisLog);
-    return null;
-  } else {
-    render_inputErrorPage(element);
-    return null;
-  }
+function renderHyPhyVision(url, element, fasta, originalFile, analysisLog) {
+  d3.json(url, (err, data) => {
+    const method = determineHyPhyMethod(data);
+    if (method != "unkownMethod" && method != "No json object was provided") {
+      const renderSpecificMethod = methodDict[method];
+      renderSpecificMethod(data, element, fasta, originalFile, analysisLog);
+      return null;
+    } else {
+      render_inputErrorPage(element);
+      return null;
+    }
+  });
 }
 
 module.exports = renderHyPhyVision;

--- a/src/renderHyPhyVision.js
+++ b/src/renderHyPhyVision.js
@@ -1,36 +1,35 @@
-import { default as absrel } from "./jsx/absrel.jsx";
-import { default as busted } from "./jsx/busted.jsx";
-import { default as fel } from "./jsx/fel.jsx";
-import { default as meme } from "./jsx/meme.jsx";
-import { default as prime } from "./jsx/prime.jsx";
-import { default as relax } from "./jsx/relax.jsx";
-import { default as slac } from "./jsx/slac.jsx";
-import { default as fubar } from "./jsx/fubar.jsx";
-import { default as gard } from "./jsx/gard.jsx";
-import { default as bgm } from "./jsx/bgm.jsx";
-import { default as fade } from "./jsx/fade.jsx";
+import { default as render_absrel } from "./jsx/absrel.jsx";
+import { default as render_busted } from "./jsx/busted.jsx";
+import { default as render_fel } from "./jsx/fel.jsx";
+import { default as render_meme } from "./jsx/meme.jsx";
+import { default as render_prime } from "./jsx/prime.jsx";
+import { default as render_relax } from "./jsx/relax.jsx";
+import { default as render_slac } from "./jsx/slac.jsx";
+import { default as render_fubar } from "./jsx/fubar.jsx";
+import { default as render_gard } from "./jsx/gard.jsx";
+import { default as render_bgm } from "./jsx/bgm.jsx";
+import { default as render_fade } from "./jsx/fade.jsx";
 import { default as determineHyPhyMethod } from "./helpers/determineHyPhyMethod.js";
 import { default as render_inputErrorPage } from "./jsx/components/inputErrorPage.jsx";
 
 const methodDict = {
-  absrel: absrel,
-  busted: busted,
-  fel: fel,
-  meme: meme,
-  prime: prime,
-  relax: relax,
-  slac: slac,
-  fubar: fubar,
-  gard: gard,
-  bgm: bgm,
-  fade: fade
+  absrel: render_absrel,
+  busted: render_busted,
+  fel: render_fel,
+  meme: render_meme,
+  prime: render_prime,
+  relax: render_relax,
+  slac: render_slac,
+  fubar: render_fubar,
+  gard: render_gard,
+  bgm: render_bgm,
+  fade: render_fade
 };
 
 function renderHyPhyVision(data, element, fasta, originalFile, analysisLog) {
   const method = determineHyPhyMethod(data);
-  if (method != "unkownMethod" && method != "No json object was proviced") {
+  if (method != "unkownMethod" && method != "No json object was provided") {
     const renderSpecificMethod = methodDict[method];
-    console.log("renderSpecificMethod: ", renderSpecificMethod);
     renderSpecificMethod(data, element, fasta, originalFile, analysisLog);
     return null;
   } else {


### PR DESCRIPTION
Provide one render_function to render the correct HyPhy-vision page for any HyPhy json result. The function looks at the json result, determines which HyPhy method produced it, and then calls the appropriate render function (i.e. `render_absrel`, `render_relax`, etc).

This will simplify the interface for Galaxy. This could also be used to simplify the codebase for other applications (vision.hyphy.org, datamonkey, gui) but right now it's just for use on galaxy. This will allow the replacement of the ten individual vizs with one.

<img width="567" alt="screen shot 2019-02-08 at 8 24 46 am" src="https://user-images.githubusercontent.com/25244432/52480959-2d26cc80-2b7b-11e9-9c36-1b5075ce0f45.png">

This PR is targeting master so that we can release and use in galaxy quickly.
