### PR TITLE
Fix grayscale toggle in tree components

### DIFF
--- a/src/jsx/components/tree.jsx
+++ b/src/jsx/components/tree.jsx
@@ -61,7 +61,7 @@ var Tree = React.createClass({
     this.setState({
       omega_color: omega_color,
       omega_scale: omega_scale,
-      fill_color: false
+      fill_color: fill_color
     });
   },
 


### PR DESCRIPTION
It looks like the Tree component was not changing color correctly on `GrayScale` toggle because changes to the `omega_color` and `omega_scale` objects was not enough for React to trigger an update. Although these objects were being changed correctly based on the checked state of the `GrayScale` option, `fill_color` was not being updated in the state appropriately (presumably this object is easier for React to watch; previously it was always being set to `false` and never updated to the new `fill_color`), and the tree never changed :cry: 