### PR TITLE
Fix default checked state for `Hide Legend` setting based on analysis

### DIFF
--- a/src/jsx/components/tree.jsx
+++ b/src/jsx/components/tree.jsx
@@ -536,7 +536,7 @@ var Tree = React.createClass({
             type="checkbox"
             id="hyphy-tree-hide-legend"
             className="hyphy-tree-trigger"
-            defaultChecked={false}
+            defaultChecked={!this.state.show_legend}
             onChange={this.toggleLegend}
           />{" "}
           Hide Legend


### PR DESCRIPTION
Not all analyses want a legend to be displayed initially, and so an initial `show_legend` state is set based on the analysis being visualized. The legend is/is not initially displayed *correctly* based on this value. Previously, the `Hide Legend` option was always unchecked by default, however. Now, the initial checked state is based on the selected analysis (via `state.show_legend` set in `getInitialState`)