### PR TITLE
Partitioned data hot fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ web/docs/public
 *.map
 jsx-compiled
 dist
+public

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "git://github.com/veg/hyphy-vision.git"
   },
   "main": "dist/hyphyvision.js",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.3.1",
     "alignment.js": "1.0.10",

--- a/server.js
+++ b/server.js
@@ -1,17 +1,16 @@
-const express = require('express'),
-  path = require('path');
-
+const express = require("express"),
+  path = require("path");
 
 const port = process.env.PORT || 8000;
 const app = express();
 
-app.use(express.static('.'));
-app.use(express.static('dist'));
+app.use(express.static("."));
+app.use(express.static("public"));
 
-app.get('/:methods/?', (req,res)=>{
-  res.sendFile(path.resolve(__dirname, 'dist', 'index.html'));
+app.get("/:methods/?", (req, res) => {
+  res.sendFile(path.resolve(__dirname, "public", "index.html"));
 });
 
-app.listen(port, ()=>{
-  console.log('Listening on port', port, '...');
+app.listen(port, () => {
+  console.log("Listening on port", port, "...");
 });

--- a/src/jsx/components/input_info.jsx
+++ b/src/jsx/components/input_info.jsx
@@ -36,7 +36,6 @@ class InputInfo extends React.Component {
     var filename = is_full_path
       ? _.last(this.props.input_data["file name"].split("/"))
       : this.props.input_data["file name"];
-    var show_partition_button = this.props.gard;
     return (
       <div className="row" id="input-info">
         <div className="col-md-8">
@@ -98,7 +97,7 @@ class InputInfo extends React.Component {
                     </li>
                   ]
                 : null}
-              {show_partition_button ? (
+              {this.props.partitionedData ? (
                 <li className="dropdown-item">
                   <a href={window.location.href + "/screened_data/"}>
                     Partitioned data

--- a/src/jsx/components/methodheader.jsx
+++ b/src/jsx/components/methodheader.jsx
@@ -19,6 +19,7 @@ function MethodHeader(props) {
           fasta={props.fasta}
           originalFile={props.originalFile}
           analysisLog={props.analysisLog}
+          partitionedData={props.partitionedData}
         />
       </div>
     </div>

--- a/src/jsx/components/results_page.jsx
+++ b/src/jsx/components/results_page.jsx
@@ -112,6 +112,7 @@ class ResultsPage extends React.Component {
                   fasta={this.props.fasta}
                   originalFile={this.props.originalFile}
                   analysisLog={this.props.analysisLog}
+                  partitionedData={this.props.partitionedData}
                 />
               </div>
             </div>

--- a/src/jsx/gard.jsx
+++ b/src/jsx/gard.jsx
@@ -474,19 +474,28 @@ function GARD(props) {
       fasta={props.fasta}
       originalFile={props.originalFile}
       analysisLog={props.analysisLog}
+      partitionedData={props.partitionedData}
     >
       {GARDContents}
     </ResultsPage>
   );
 }
 
-function render_gard(data, element, fasta, originalFile, analysisLog) {
+function render_gard(
+  data,
+  element,
+  fasta,
+  originalFile,
+  analysisLog,
+  partitionedData
+) {
   ReactDOM.render(
     <GARD
       data={data}
       fasta={fasta}
       originalFile={originalFile}
       analysisLog={analysisLog}
+      partitionedData={partitionedData}
     />,
     document.getElementById(element)
   );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ config = {
     historyApiFallback: true
   },
   output: {
-    path: path.resolve(__dirname, "dist/"),
+    path: path.resolve(__dirname, "public/"),
     filename: "[name].js",
     library: "hyphyVision"
   },
@@ -117,7 +117,7 @@ config = {
     new webpack.IgnorePlugin(/jsdom$/),
     new HtmlWebpackPlugin({
       title: "HyPhy Vision",
-      filename: path.resolve("dist", "index.html")
+      filename: path.resolve("public", "index.html")
     }),
     new ExtractTextPlugin("[name].css")
   ],


### PR DESCRIPTION
This enacts a bug fix for obtaining partitioned data on datamonkey, which should maintain compatibility with the standalone vision app, Galaxy, and Electron.

Also, the standalone app now builds in the `./public` folder. I found it cumbersome to test both the standalone app and library with the current setup. Also, standalone app bundles have been pushed to NPM before (instead of libraries); this should prevent that.

Tested on my personal datamonkey instance (but not with Galaxy or Electron).